### PR TITLE
Add Xvfb setup in Dockerfile for GUI compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM python:3.13-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gcc g++ swig libgl1-mesa-glx && \
-    useradd --create-home appuser && \
-    mkdir -p /home/appuser/app && \
-    chown -R appuser:appuser /home/appuser
+    apt-get install -y --no-install-recommends \
+        gcc \
+        g++ \
+        swig \
+        libgl1-mesa-glx \
+        xvfb \
+        x11-xserver-utils \
+    && useradd --create-home appuser \
+    && mkdir -p /home/appuser/app \
+    && chown -R appuser:appuser /home/appuser
 
 WORKDIR /home/appuser/app
 
@@ -29,4 +35,4 @@ USER appuser
 
 EXPOSE 50051
 
-CMD ["python", "server.py"]
+CMD /bin/sh -c "Xvfb :1 -screen 0 1024x768x24 & export DISPLAY=:1 && python server.py"


### PR DESCRIPTION
Xvfb and related dependencies were added to support graphical applications in the container. The CMD command was updated to launch Xvfb and set the DISPLAY environment variable before running the server. This ensures compatibility for applications requiring a virtual display.