### PR TITLE
Handle missing X server lock file gracefully in server initialization

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -269,6 +269,11 @@ if __name__ == "__main__":
     import os
     os.environ["SDL_VIDEODRIVER"] = "dummy"
 
+    try:
+        os.remove("/tmp/.X1-lock")
+    except FileNotFoundError:
+        pass
+
     import pygame
     pygame.init()
     serve()


### PR DESCRIPTION
- Added logic to remove `/tmp/.X1-lock` if it exists, with a fallback for `FileNotFoundError`, preventing potential server startup issues caused by stale lock files.