### PR TITLE
Remove redundant X server lock file handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ USER appuser
 
 EXPOSE 50051
 
-CMD /bin/sh -c "Xvfb :1 -screen 0 1024x768x24 & export DISPLAY=:1 && python server.py"
+CMD /bin/sh -c "rm -f /tmp/.X1-lock && Xvfb :1 -screen 0 1024x768x24 & export DISPLAY=:1 && python server.py"

--- a/src/server.py
+++ b/src/server.py
@@ -269,11 +269,6 @@ if __name__ == "__main__":
     import os
     os.environ["SDL_VIDEODRIVER"] = "dummy"
 
-    try:
-        os.remove("/tmp/.X1-lock")
-    except FileNotFoundError:
-        pass
-
     import pygame
     pygame.init()
     serve()


### PR DESCRIPTION
Remove redundant X server lock file handling in `server.py`, shift cleanup to Dockerfile CMD